### PR TITLE
Improved initialization and config upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ const BUFFER_SIZE: usize = 512;
 /// - This is a limitation from your device or its HAL.
 let mut bmi = Bmi2::<_, _, BUFFER_SIZE>::new_i2c(
     i2c, 
+    delay,
     I2cAddr::Alternative, 
-    Burst::Other(255),
-    delay
+    Burst::new(255),
 );
 
 /// Get the chip id. Should be 0x24 or 36 in decimal

--- a/README.md
+++ b/README.md
@@ -8,32 +8,39 @@ This is an [embedded-hal](https://github.com/rust-embedded/embedded-hal) driver 
 
 ```rust
 // ...
-
 use bmi2::Bmi2;
 use bmi2::config;
 use bmi2::{types::Burst, I2cAddr, types::PwrCtrl};
+use embedded_hal::delay::DelayNs;
+
+// Specify your delay type, for example:
+let delay = MyDelay::new(); // Replace with your actual delay implementation
+
+// Choose a buffer size (e.g., 512 bytes), needs to be >= max data burst
+const BUFFER_SIZE: usize = 512;
 
 /// Create a new Bmi2 device using I2C with its alternative address (0x69).
 /// Configure the max data burst to 255 bytes:
 /// - used for the upload of the configuration during initialization.
-/// - This is a limitation from your device or its HAL. 
-let mut bmi = Bmi2::new_i2c(i2c, I2cAddr::Alternative, Burst::Other(255));
+/// - This is a limitation from your device or its HAL.
+let mut bmi = Bmi2::<_, _, BUFFER_SIZE>::new_i2c(
+    i2c, 
+    I2cAddr::Alternative, 
+    Burst::Other(255),
+    delay
+);
 
 /// Get the chip id. Should be 0x24 or 36 in decimal
 let chip_id = bmi.get_chip_id().unwrap();
-
 /// Initialize the senor.
 /// During this process a configuration of > 8kB is uploaded to the sensor.
 /// Alternatively, for the BMI260 call its dedicated config:
 /// bmi.init(&config::BMI260_CONFIG_FILE).unwrap();
 bmi.init(&config::BMI270_CONFIG_FILE).unwrap();
-
 /// Enable power for the accelerometer and the gyroscope.
 let pwr_ctrl = PwrCtrl { aux_en: false, gyr_en: true, acc_en: true, temp_en: false };
 bmi.set_pwr_ctrl(pwr_ctrl).unwrap();
-
 /// Read the raw data
 let data = bmi.get_data().unwrap();
-
 // ...
 ```

--- a/src/bmi2.rs
+++ b/src/bmi2.rs
@@ -711,13 +711,32 @@ where
         Ok(())
     }
 
+    /// Disable power save mode.
+    pub fn disable_power_save(&mut self) -> Result<(), Error<CommE>> {
+        let mut pwr_conf = self.get_pwr_conf()?;
+        pwr_conf.power_save = false;
+        self.set_pwr_conf(pwr_conf)?;
+        // Critical delay after disabling power save
+        self.delay.delay_us(450);
+        Ok(())
+    }
+
+    /// Enable power save mode.
+    pub fn enable_power_save(&mut self) -> Result<(), Error<CommE>> {
+        let mut pwr_conf = self.get_pwr_conf()?;
+        pwr_conf.power_save = true;
+        self.set_pwr_conf(pwr_conf)?;
+        // Critical delay after enabling power save
+        self.delay.delay_us(450);
+        Ok(())
+    }
+
+
     /// Initialize sensor.
     pub fn init(&mut self, config_file: &[u8]) -> Result<(), Error<CommE>> {
 
         // Disable advanced power mode
-        let mut pwr_conf = self.get_pwr_conf()?;
-        pwr_conf.power_save = false;
-        self.set_pwr_conf(pwr_conf)?;
+        self.disable_power_save()?;
 
         let mut preallocated_space = alloc_stack!([u8; N]);
         let mut vec = FixedVec::new(&mut preallocated_space);

--- a/src/bmi2.rs
+++ b/src/bmi2.rs
@@ -15,7 +15,6 @@ use crate::types::{
 pub struct Bmi2<I, D, const N: usize> {
     iface: I,
     max_burst: u16,
-    buffer: [u8; N],
     delay: D,
 }
 
@@ -28,7 +27,6 @@ impl<I2C, D, const N: usize> Bmi2<I2cInterface<I2C>, D, N> {
                 address: address.addr(),
             },
             max_burst: burst.val(),
-            buffer: [0; N],
             delay,
         }
     }
@@ -48,7 +46,6 @@ where
         Bmi2 {
             iface: SpiInterface { spi },
             max_burst: burst.val(),
-            buffer: [0; N],
             delay,
         }
     }
@@ -722,8 +719,7 @@ where
         pwr_conf.power_save = false;
         self.set_pwr_conf(pwr_conf)?;
 
-        // TODO allow config of pre alloc
-        let mut preallocated_space = alloc_stack!([u8; 512]);
+        let mut preallocated_space = alloc_stack!([u8; N]);
         let mut vec = FixedVec::new(&mut preallocated_space);
 
         let mut offset = 0u16;

--- a/src/bmi2.rs
+++ b/src/bmi2.rs
@@ -790,7 +790,7 @@ where
             vec.push_all(&config_file[offset as usize..end as usize])
                 .map_err(|_| Error::Alloc)?;
             
-            self.iface.write(&mut vec.as_mut_slice())?;
+            self.iface.write(vec.as_mut_slice())?;
             
             offset += chunk_size;
             self.delay.delay_us(2);

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -75,18 +75,18 @@ where
         payload[0] += 0x80;
 
         // `write` asserts and deasserts CS for us. No need to do it manually!
-        let res = self.spi.write(&payload).map_err(Error::Comm);
+        
 
-        res
+        self.spi.write(payload).map_err(Error::Comm)
     }
 
     fn write_reg(&mut self, register: u8, data: u8) -> Result<(), Self::Error> {
         let payload: [u8; 2] = [register + 0x80, data];
 
         // `write` asserts and deasserts CS for us. No need to do it manually!
-        let res = self.spi.write(&payload).map_err(Error::Comm);
+        
 
-        res
+        self.spi.write(&payload).map_err(Error::Comm)
     }
 }
 

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -15,6 +15,7 @@ impl Registers {
     pub const INTERNAL_STATUS: u8 = 0x21;
     pub const TEMPERATURE_0: u8 = 0x22;
     pub const FIFO_LENGTH_0: u8 = 0x24;
+    #[allow(dead_code)]
     pub const FIFO_DATA: u8 = 0x26;
     pub const ACC_CONF: u8 = 0x40;
     pub const ACC_RANGE: u8 = 0x41;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,7 @@
+pub const BMI160_CHIP_ID: u8 = 0xD1;
+pub const BMI260_CHIP_ID: u8 = 0x27;
+pub const BMI270_CHIP_ID: u8 = 0x24;
+
 /// The possible errors that could be encountered.
 #[derive(Debug)]
 pub enum Error<CommE> {
@@ -5,6 +9,12 @@ pub enum Error<CommE> {
     Comm(CommE),
     /// Memory allocation error during initialization.
     Alloc,
+    /// Invalid Chip Id.
+    InvalidChipId,
+    /// Buffer too small.
+    BufferTooSmall,
+    /// Initialization Failed.
+    InitFailed,
 }
 
 /// Data burst.

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,25 +8,48 @@ pub enum Error<CommE> {
 }
 
 /// Data burst.
-pub enum Burst {
-    /// Burst of 512 bytes.
+pub struct Burst {
+    max: u16,
+    kind: BurstKind,
+}
+
+enum BurstKind {
     Max,
-    /// An other burst amount under 512 bytes.
     Other(u16),
 }
 
-impl Default for Burst {
+impl Default for BurstKind {
     fn default() -> Self {
-        Burst::Max
+        Self::Max
     }
 }
 
 impl Burst {
-    pub fn val(self) -> u16 {
-        match self {
-            Burst::Max => 512,
-            Burst::Other(v) => v % 512,
+    pub fn new(max: u16) -> Self {
+        Self {
+            max,
+            kind: BurstKind::default(),
         }
+    }
+
+    pub fn custom(max: u16, value: u16) -> Self {
+        Self {
+            max,
+            kind: BurstKind::Other(value),
+        }
+    }
+
+    pub fn val(&self) -> u16 {
+        match self.kind {
+            BurstKind::Max => self.max,
+            BurstKind::Other(v) => v.min(self.max),
+        }
+    }
+}
+
+impl Default for Burst {
+    fn default() -> Self {
+        Self::new(512)
     }
 }
 


### PR DESCRIPTION
This PR:

- fixes a TODO by making the prealloc buffer size configurable via const generics
- let's the driver take in a delay and uses that in the init function
- updates the `Burst` struct to take in values larger than 512
- udates the init function to be more careful and include more checks, heavily inspired by the steps from the official C driver

The reasons for this are:
- users might have much larger burst sizes
  - for example, I do my i2c development on a Linux machine with an i2c bus where I can do writes of 8192 bytes from userspace and with a custom driver or kernel module I could easily do a multiple of that
- I found the init function to not properly set up the internal ASIC of the BMI270. In particular, I found:
  - that the Softreset is mandatory before uploading the config
  - the delays are critical, especially the 20ms delay after finishing the config file upload and the 450us after dis- or enabling the advanced power save mode
  - writing of the config file needs to happen in two-bytes increments, there should be an odd number of bytes written in one go